### PR TITLE
Update screenshot URL

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -18,7 +18,7 @@ index 669927a..b39ba6f 100644
 -    <screenshot height="640" width="881" type="default">
 -      <image>http://glabels.org/images/320-screenshot-main.png</image>
 +    <screenshot type="default" height="640" width="881">
-+      <image>https://github.com/hfiguiere/org.gnome.glabels-3/raw/gnome40/320-screenshot-main.png</image>
++      <image>https://raw.githubusercontent.com/flathub/org.gnome.glabels-3/master/320-screenshot-main.png</image>
      </screenshot>
    </screenshots>
 @@ -34,4 +34,14 @@


### PR DESCRIPTION
This will use the screenshot in this repository.

For the record the original domain for this screenshot redirect to a github repo.